### PR TITLE
Complex config support: Implement Block.Merge(), improve string representation.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,8 +28,24 @@ func StringValue(v string) Value   { return Value{typ: stringType, s: v} }
 func Float64Value(v float64) Value { return Value{typ: numberType, f: v} }
 func BoolValue(v bool) Value       { return Value{typ: booleanType, b: v} }
 
-func (cv Value) String() (string, bool) {
-	return cv.s, cv.typ == stringType
+func (cv Value) GoString() string {
+	switch cv.typ {
+	case stringType:
+		return fmt.Sprintf("config.StringValue(%q)", cv.s)
+	case numberType:
+		return fmt.Sprintf("config.Float64Value(%v)", cv.f)
+	case booleanType:
+		return fmt.Sprintf("config.BoolValue(%v)", cv.b)
+	}
+	return "<invalid config.Value>"
+}
+
+func (cv Value) IsString() bool {
+	return cv.typ == stringType
+}
+
+func (cv Value) String() string {
+	return fmt.Sprintf("%v", cv.Interface())
 }
 
 func (cv Value) Number() (float64, bool) {

--- a/config/config.go
+++ b/config/config.go
@@ -70,7 +70,7 @@ func (cv Value) unmarshal(v reflect.Value) error {
 		cvt = reflect.TypeOf(cv.f)
 		cvv = reflect.ValueOf(cv.f)
 	default:
-		panic("received Value with unknown type")
+		return fmt.Errorf("unexpected Value type: %v", cv.typ)
 	}
 
 	if cvt.ConvertibleTo(rvt) {

--- a/config/config.go
+++ b/config/config.go
@@ -7,22 +7,18 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-type ValueType int
+type valueType int
 
 const (
-	stringType ValueType = iota
+	stringType valueType = iota
 	numberType
 	booleanType
 )
 
-func (cvt ValueType) String() string {
-	return [3]string{"StringValue", "Number", "Boolean"}[cvt]
-}
-
 // Value may be either a string, float64 or boolean value.
 // This is the Go equivalent of the C type "oconfig_value_t".
 type Value struct {
-	typ ValueType
+	typ valueType
 	s   string
 	f   float64
 	b   bool
@@ -85,7 +81,7 @@ func (cv Value) unmarshal(v reflect.Value) error {
 		v.Set(reflect.Append(v, cvv.Convert(rvt.Elem())))
 		return nil
 	}
-	return fmt.Errorf("cannot unmarshal %s type config value to type %s", cv.typ, v.Type())
+	return fmt.Errorf("cannot unmarshal a %T to a %s", cv.Interface(), v.Type())
 }
 
 // Block represents one configuration block, which may contain other configuration blocks.

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -434,7 +434,7 @@ func wrap_log_callback(sev C.int, msg *C.char, ud *C.user_data_t) C.int {
 
 // Configurer implements a Configure callback.
 type Configurer interface {
-	Configure(context.Context, interface{})
+	Configure(context.Context, config.Block) error
 }
 
 // Configurers are registered once but Configs may be received multiple times and merged together before unmarshalling,


### PR DESCRIPTION
The `IsString()` method is identical to [`"collectd.org/meta".Entry.IsString`](https://godoc.org/collectd.org/meta#Entry.IsString).

`Block.Merge()` is going to be needed by the `plugin` package.